### PR TITLE
Fix round state handling in CleanPooledPair

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.Recycle.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Recycle.cs
@@ -116,12 +116,16 @@ public sealed partial class TestPair : IAsyncDisposable
             case PairState.Dead:
             case PairState.Ready:
                 break;
+    
             case PairState.InUse:
-                await _testOut.WriteLineAsync($"{nameof(DisposeAsync)}: Dirty return of pair {Id} started");
-                await OnDirtyDispose();
+                await _testOut.WriteLineAsync($"{nameof(DisposeAsync)}: Clean return of pair {Id} started via DisposeAsync");
+                State = PairState.CleanDisposed;
+                await OnCleanDispose();
+                State = PairState.Ready;
                 PoolManager.NoCheckReturn(this);
                 ClearContext();
                 break;
+    
             default:
                 throw new Exception($"{nameof(DisposeAsync)}: Unexpected state. Pair: {Id}. State: {State}.");
         }


### PR DESCRIPTION
Changed how we log warnings when the client or server crashes in tests.  
Before, the code was trying to pass two arguments to `Assert.Warn`, but that method only accepts one.  
So now we just combine the message and the exception into a single string using interpolation.  